### PR TITLE
Extended life of SodiumCtx

### DIFF
--- a/src/Main.ts
+++ b/src/Main.ts
@@ -9,8 +9,10 @@ const main = async () => {
 
     wasmLib.hello_world();
 
+    var sodium_ctx = wasmLib.sodium_ctx_new();
+
     //Works!
-    const ptr = wasmLib.start_frp("hello from sodium!", x => document.getElementById("text").innerText= x); 
+    const ptr = wasmLib.start_frp(sodium_ctx, "hello from sodium!", x => document.getElementById("text").innerText= x); 
 
     //Doesn't work...
     wasmLib.send_frp(ptr, 42);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,18 @@ pub fn hello_world() {
 }
 
 #[wasm_bindgen]
-pub fn start_frp(state:&JsValue, on_tick:&js_sys::Function) -> *mut StreamSink<i32> { 
+pub fn sodium_ctx_new() -> *const SodiumCtx {
+    Box::into_raw(Box::new(SodiumCtx::new()))
+}
+
+#[wasm_bindgen]
+pub fn start_frp(sodium_ctx: *const SodiumCtx, state:&JsValue, on_tick:&js_sys::Function) -> *mut StreamSink<i32> { 
     let this = &JsValue::null();
-   
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
-    let s_tick: StreamSink<i32> = sodium_ctx.new_stream_sink();
     
+    let sodium_ctx = unsafe { &*sodium_ctx };
+    
+    let s_tick: StreamSink<i32> = sodium_ctx.new_stream_sink();
+
     // these 3 are being captured, so clone the reference to obtain the
     // value of type js-reference instead of the reference to a js-reference
     let this = this.clone();


### PR DESCRIPTION
You can probably create something like an AppCtx for your applications state which can hold your SodiumCtx if you like. This is just a small change to get your example working.